### PR TITLE
feat: internal storage secret

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -1,3 +1,3 @@
 #include "globals.h"
 
-const internalStorage_t N_storage_real;
+const internalStorage_t N_storage_real = {0};

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,0 +1,3 @@
+#include "globals.h"
+
+const internalStorage_t N_storage_real;

--- a/src/globals.h
+++ b/src/globals.h
@@ -37,3 +37,9 @@ extern io_state_e G_io_state;
  * Global context for user requests.
  */
 extern global_ctx_t G_context;
+
+/**
+ * Persistent Storage
+ */
+extern const internalStorage_t N_storage_real;
+#define N_storage (*(volatile internalStorage_t*) PIC(&N_storage_real))

--- a/src/storage.c
+++ b/src/storage.c
@@ -1,0 +1,15 @@
+#include "storage.h"
+
+uint32_t get_secret() {
+    if (N_storage.secret == 0) {
+        // first access, generate and write to storage
+        return generate_secret();
+    }
+    return (volatile uint32_t) N_storage.secret;
+}
+
+uint32_t generate_secret() {
+    uint32_t new_secret = cx_rng_u32();
+    nvm_write((void *) &N_storage.secret, &new_secret, sizeof(uint32_t));
+    return new_secret;
+}

--- a/src/storage.h
+++ b/src/storage.h
@@ -11,7 +11,7 @@
 uint32_t get_secret(void);
 
 /**
- * Generate new rangom secret and write to N_storage.secret.
+ * Generate new random secret and write to N_storage.secret.
  *
  * @returns uint32_t the new internal secret seed;
  */

--- a/src/storage.h
+++ b/src/storage.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "globals.h"
+
+/**
+ * Get N_storage.secret.
+ * If it's the first call ever, generate and save a secret before return.
+ *
+ * @returns uint32_t the internal secret seed;
+ */
+uint32_t get_secret(void);
+
+/**
+ * Generate new rangom secret and write to N_storage.secret.
+ *
+ * @returns uint32_t the new internal secret seed;
+ */
+uint32_t generate_secret(void);

--- a/src/types.h
+++ b/src/types.h
@@ -113,3 +113,11 @@ typedef struct {
     request_type_e req_type;  /// user request
     bip32_path_t bip32_path;
 } global_ctx_t;
+
+/**
+ * Internal storage structure
+ */
+
+typedef struct internalStorage_t {
+    uint32_t secret;
+} internalStorage_t;


### PR DESCRIPTION
# Summary

related to design #28 

This will introduce a simple internal storage in the device which will be used later to sign/verify data sent to ledger.

On ledger any global variable with the prefix `N_` is saved on persistent storage.
In this case read and write are special, write _must_ be done with `nvm_write` and read could be simply accessing the global variable but in this case it is volatile.

# Preamble

- global variables: Declared as `extern` and defined elsewhere, this makes any file importing it to always use the same storage and not some local copy.
- `volatile` : this prevents compiler optimization to use cached values and always fetch actual value when used.
- `PIC`: "position independent code", although it has many meanings and uses, in this case it's a variable (or data section) in which the address does not hold the actual data (i.e. compiler magic). 

# Acceptance criteria

- [X] Create a persistent storage struct with the uint32_t secret
- [X] Create methods to access and generate the secret