### PR TITLE
feat: show path settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ NETWORK=mainnet
 endif
 DEFINES += NETWORK=\"$(NETWORK)\"
 
-ifdef SHOW_PATH
-DEFINES += UI_SHOW_PATH=1
-endif
-
 include $(BOLOS_SDK)/Makefile.defines
 
 APP_LOAD_PARAMS  = --curve secp256k1

--- a/src/storage.c
+++ b/src/storage.c
@@ -13,3 +13,9 @@ uint32_t generate_secret() {
     nvm_write((void *) &N_storage.secret, &new_secret, sizeof(uint32_t));
     return new_secret;
 }
+
+void toggle_show_path() {
+    uint8_t show_path = N_storage.settings.show_path;
+    show_path = (show_path + 1) % 2;
+    nvm_write((void *) &N_storage.settings.show_path, &show_path, sizeof(uint8_t));
+}

--- a/src/storage.h
+++ b/src/storage.h
@@ -16,3 +16,8 @@ uint32_t get_secret(void);
  * @returns uint32_t the new internal secret seed;
  */
 uint32_t generate_secret(void);
+
+/**
+ * Toggle and save show path option.
+ */
+void toggle_show_path(void);

--- a/src/types.h
+++ b/src/types.h
@@ -113,11 +113,15 @@ typedef struct {
     request_type_e req_type;  /// user request
     bip32_path_t bip32_path;
 } global_ctx_t;
-
 /**
  * Internal storage structure
  */
 
+typedef struct AppSettings {
+    uint8_t show_path;
+} AppSettings;
+
 typedef struct internalStorage_t {
+    AppSettings settings;
     uint32_t secret;
 } internalStorage_t;

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -3,11 +3,15 @@
 #include "glyphs.h"
 
 #include "../globals.h"
+#include "../storage.h"
 #include "menu.h"
+
+static char g_path_state[30];
 
 UX_STEP_NOCB(ux_menu_ready_step, pnn, {&C_hathor_logo, "Hathor", "is ready"});
 UX_STEP_NOCB(ux_menu_version_step, bn, {"Version", APPVERSION});
 UX_STEP_CB(ux_menu_about_step, pb, ui_menu_about(), {&C_icon_certificate, "About"});
+UX_STEP_CB(ux_menu_settings_step, pb, ui_menu_settings(), {&C_icon_coggle, "Settings"});
 UX_STEP_VALID(ux_menu_exit_step, pb, os_sched_exit(-1), {&C_icon_dashboard_x, "Quit"});
 
 // FLOW for the main menu:
@@ -19,6 +23,7 @@ UX_FLOW(ux_menu_main_flow,
         &ux_menu_ready_step,
         &ux_menu_version_step,
         &ux_menu_about_step,
+        &ux_menu_settings_step,
         &ux_menu_exit_step,
         FLOW_LOOP);
 
@@ -40,4 +45,34 @@ UX_FLOW(ux_menu_about_flow, &ux_menu_info_step, &ux_menu_back_step, FLOW_LOOP);
 
 void ui_menu_about() {
     ux_flow_init(0, ux_menu_about_flow, NULL);
+}
+
+void toggle_show_path_action() {
+    toggle_show_path();
+
+    // gimmick to redisplay show_path step with new settings;
+    ui_menu_settings();
+    ux_flow_next();
+}
+
+UX_STEP_NOCB(ux_menu_settings1_step, bn, {"Settings", ""});
+UX_STEP_CB(ux_menu_settings_show_path_step,
+           bn,
+           toggle_show_path_action(),
+           {"Show bip32 path", g_path_state});
+
+// FLOW for the settings submenu:
+// #1 screen: Settings
+// #2 screen: toggle show_path settings
+UX_FLOW(ux_menu_settings_flow,
+        &ux_menu_settings1_step,
+        &ux_menu_settings_show_path_step,
+        &ux_menu_back_step,
+        FLOW_LOOP);
+
+void ui_menu_settings() {
+
+    strcpy(g_path_state, N_storage.settings.show_path ? "on" : "off");
+
+    ux_flow_init(0, ux_menu_settings_flow, NULL);
 }

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -9,3 +9,13 @@ void ui_menu_main(void);
  * Show about submenu (copyright, date).
  */
 void ui_menu_about(void);
+
+/**
+ * Show settings submenu.
+ */
+void ui_menu_settings(void);
+
+/**
+ * Action to toggle show_path settings.
+ */
+void toggle_show_path_action(void);


### PR DESCRIPTION
# Summary

Previously we could enable showing the bip32 paths on some commands on compilation, so this would only be useful for development, but having this as a setting allows users to toggle this option at runtime.

# Acceptance criteria