### PR TITLE
feat: Add commas to output value

### DIFF
--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -204,7 +204,7 @@ void prepare_display_output() {
     // set g_ammount (HTR value)
     memset(g_amount, 0, sizeof(g_amount));
     strcpy(g_amount, "HTR ");
-    format_fpu64(g_amount + 4, sizeof(g_amount) - 5, output.value, 2);
+    format_value(output.value, g_amount + 4);
 }
 
 void ui_confirm_output(bool choice) {


### PR DESCRIPTION
# Acceptance criteria

Include comma separation for periods (thousands, millions, etc.)

Instead of `1234567890.00` display `1,234,567,890.00`