### PR TITLE
tests(integration): skip first screen to allow tests to run

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,10 +1,14 @@
 # End-to-end tests
 
-These tests are implemented in Python and can be executed either using the [Speculos](https://github.com/LedgerHQ/speculos) emulator or a Ledger Nano S/X.
-Python dependencies are listed in [requirements.txt](requirements.txt), install them using [pip](https://pypi.org/project/pip/)
+The tests are implemented in python and need a Speculos emulator to run.
+Python dependencies are listed in [pyproject.toml](pyproject.toml), install them using [poetry](https://github.com/python-poetry/poetry)
+
+Some basic commands are defined on the Makefile.
 
 ```
-pip install -r requirements.txt
+poetry install
+# or
+make install
 ```
 
 ### Launch with Speculos
@@ -18,19 +22,7 @@ First start your application with Speculos
 then in the `tests` folder run
 
 ```
-pytest
-```
-
-### Launch with your Nano S/X
-
-To run the tests on your Ledger Nano S/X you also need to install an optional dependency
-
-```
-pip install ledgercomm[hid]
-```
-
-Be sure to have you device connected through USB (without any other software interacting with it) and run
-
-```
-pytest --hid
+poetry run pytest
+# or
+make test
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,7 @@ def cmd(transport):
 
     yield command
 
+
 @pytest.fixture(scope="session", autouse=True)
 def skip_pending_review_screen(server):
     # This is meant to run before all tests
@@ -104,6 +105,7 @@ def skip_pending_review_screen(server):
         urljoin(server, "/button/both"),
         json={"action": "press-and-release"},
     )
+
 
 @pytest.fixture(scope="session")
 def public_key_bytes():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,10 @@ Addresses: m/44'/280'/0'/0/0-9
 """
 
 from pathlib import Path
+from urllib.parse import urljoin
 
 import pytest
+import requests
 
 from app_client.automation import CommandAutomation, FakeAutomation
 from app_client.cmd import Command
@@ -92,6 +94,16 @@ def cmd(transport):
 
     yield command
 
+@pytest.fixture(scope="session", autouse=True)
+def skip_pending_review_screen(server):
+    # This is meant to run before all tests
+    # It will press both buttons once to skip the Pending Ledger Review screen
+    # If the screen does not appear it will press both buttons on the home screen
+    # Which is a noop
+    requests.post(
+        urljoin(server, "/button/both"),
+        json={"action": "press-and-release"},
+    )
 
 @pytest.fixture(scope="session")
 def public_key_bytes():


### PR DESCRIPTION
# Acceptance criteria

During tests, allow pytest to skip the first "Pending Ledger Review".