### PR TITLE
chore: fix build warnings

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -92,6 +92,10 @@ jobs:
           nohup bash -c "python /speculos/speculos.py bin/app.elf --sdk 2.0 --display headless" > speculos.log 2<&1 &
           cd tests && make install && make test
 
+      - name: Show speculos log
+        run: |
+          cat speculos.log
+
       - name: Upload Speculos log
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -93,10 +93,12 @@ jobs:
           cd tests && make install && make test
 
       - name: Show speculos log
+        if: success() || failure()
         run: |
           cat speculos.log
 
       - name: Upload Speculos log
+        if: success() || failure()
         uses: actions/upload-artifact@v2
         with:
           name: speculos-log

--- a/src/handler/get_address.c
+++ b/src/handler/get_address.c
@@ -1,4 +1,5 @@
 #include <stdint.h>  // uint*_t
+#include <string.h>  // memmove, explicit_bzero
 
 #include "get_address.h"
 #include "../globals.h"

--- a/src/handler/sign_tx.c
+++ b/src/handler/sign_tx.c
@@ -217,7 +217,6 @@ bool sign_tx_with_key() {
     }
 
     cx_ecfp_private_key_t private_key = {0};
-    cx_ecfp_public_key_t public_key = {0};
 
     uint8_t chain_code[32];
 
@@ -225,7 +224,6 @@ bool sign_tx_with_key() {
                        chain_code,
                        G_context.bip32_path.path,
                        G_context.bip32_path.length);
-    init_public_key(&private_key, &public_key);
 
     if (G_context.tx_info.sighash_all[0] == '\0') {
         // finish sha256 from data
@@ -257,7 +255,6 @@ bool sign_tx_with_key() {
                                     NULL));
 
     explicit_bzero(&private_key, sizeof(private_key));
-    explicit_bzero(&public_key, sizeof(public_key));
 
     // exchange signature
     // io_send_response < 0 means faillure

--- a/src/handler/sign_tx.c
+++ b/src/handler/sign_tx.c
@@ -197,11 +197,11 @@ void sighash_all_hash(buffer_t *cdata) {
     // cx_hash returns the size of the hash after adding the data, we can safely ignore it
 
     CX_THROW(cx_hash_no_throw(&G_context.tx_info.sha256.header,  // hash context pointer
-            0,                                 // mode (supports: CX_LAST)
-            cdata->ptr + cdata->offset,        // Input data to add to current hash
-            cdata->size - cdata->offset,       // Length of input data
-            NULL,
-            0));  // output (if flag CX_LAST was set)
+                              0,                                 // mode (supports: CX_LAST)
+                              cdata->ptr + cdata->offset,   // Input data to add to current hash
+                              cdata->size - cdata->offset,  // Length of input data
+                              NULL,
+                              0));  // output (if flag CX_LAST was set)
 }
 
 /**
@@ -230,19 +230,19 @@ bool sign_tx_with_key() {
     if (G_context.tx_info.sighash_all[0] == '\0') {
         // finish sha256 from data
         CX_THROW(cx_hash_no_throw(&G_context.tx_info.sha256.header,
-                CX_LAST,
-                G_context.tx_info.sighash_all,
-                0,
-                G_context.tx_info.sighash_all,
-                32));
+                                  CX_LAST,
+                                  G_context.tx_info.sighash_all,
+                                  0,
+                                  G_context.tx_info.sighash_all,
+                                  32));
         // now get second sha256
         cx_sha256_init(&G_context.tx_info.sha256);
         CX_THROW(cx_hash_no_throw(&G_context.tx_info.sha256.header,
-                CX_LAST,
-                G_context.tx_info.sighash_all,
-                32,
-                G_context.tx_info.sighash_all,
-                32));
+                                  CX_LAST,
+                                  G_context.tx_info.sighash_all,
+                                  32,
+                                  G_context.tx_info.sighash_all,
+                                  32));
     }
 
     uint8_t out[256] = {0};

--- a/src/hathor.c
+++ b/src/hathor.c
@@ -65,19 +65,26 @@ void derive_private_key(cx_ecfp_private_key_t *private_key,
                         uint8_t chain_code[static 32],
                         const uint32_t *bip32_path,
                         uint8_t bip32_path_len) {
-  cx_err_t error = CX_OK;
-  uint8_t raw_privkey[65];
+    cx_err_t error = CX_OK;
+    uint8_t raw_privkey[65];
 
-  CX_CHECK(os_derive_bip32_with_seed_no_throw(HDW_NORMAL, CX_CURVE_256K1, bip32_path, bip32_path_len, raw_privkey, chain_code, NULL, 0));
+    CX_CHECK(os_derive_bip32_with_seed_no_throw(HDW_NORMAL,
+                                                CX_CURVE_256K1,
+                                                bip32_path,
+                                                bip32_path_len,
+                                                raw_privkey,
+                                                chain_code,
+                                                NULL,
+                                                0));
 
-  CX_CHECK(cx_ecfp_init_private_key_no_throw(CX_CURVE_256K1, raw_privkey, 32, private_key));
+    CX_CHECK(cx_ecfp_init_private_key_no_throw(CX_CURVE_256K1, raw_privkey, 32, private_key));
 
-  end:
-  explicit_bzero(raw_privkey, sizeof(raw_privkey));
-  if (error != CX_OK) {
-    explicit_bzero(private_key, sizeof(cx_ecfp_256_private_key_t));
-    THROW(error);
-  }
+end:
+    explicit_bzero(raw_privkey, sizeof(raw_privkey));
+    if (error != CX_OK) {
+        explicit_bzero(private_key, sizeof(cx_ecfp_256_private_key_t));
+        THROW(error);
+    }
 }
 
 void init_public_key(cx_ecfp_private_key_t *private_key, cx_ecfp_public_key_t *public_key) {

--- a/src/hathor.c
+++ b/src/hathor.c
@@ -68,19 +68,19 @@ void derive_private_key(cx_ecfp_private_key_t *private_key,
     uint8_t raw_private_key[64] = {0};
     // derive the seed with 44'/280'/$(bip32_path)
     cx_err_t err = os_derive_bip32_no_throw(CX_CURVE_256K1,
-                               bip32_path,
-                               bip32_path_len,
-                               raw_private_key,
-                               chain_code);
+                                            bip32_path,
+                                            bip32_path_len,
+                                            raw_private_key,
+                                            chain_code);
     if (err != CX_OK) {
         explicit_bzero(&raw_private_key, sizeof(raw_private_key));
         THROW(err);
     }
     // new private_key from raw
     err = cx_ecfp_init_private_key_no_throw(CX_CURVE_256K1,
-                             raw_private_key,
-                             sizeof(raw_private_key),
-                             private_key);
+                                            raw_private_key,
+                                            sizeof(raw_private_key),
+                                            private_key);
 
     explicit_bzero(&raw_private_key, sizeof(raw_private_key));
     if (err != CX_OK) {

--- a/src/hathor.c
+++ b/src/hathor.c
@@ -17,10 +17,10 @@ void sha256d(uint8_t *in, size_t inlen, uint8_t *out) {
 
     // sha256 of input to `buffer`
     cx_sha256_init(&hash);
-    cx_hash(&hash.header, CX_LAST, in, inlen, buffer, 32);
+    CX_THROW(cx_hash_no_throw(&hash.header, CX_LAST, in, inlen, buffer, 32));
     // sha256 of buffer to `out`
     cx_sha256_init(&hash);
-    cx_hash(&hash.header, CX_LAST, buffer, 32, out, 32);
+    CX_THROW(cx_hash_no_throw(&hash.header, CX_LAST, buffer, 32, out, 32));
 }
 
 void hash160(uint8_t *in, size_t inlen, uint8_t *out) {
@@ -31,9 +31,9 @@ void hash160(uint8_t *in, size_t inlen, uint8_t *out) {
     uint8_t buffer[32] = {0};
 
     cx_sha256_init(&u.shasha);
-    cx_hash(&u.shasha.header, CX_LAST, in, inlen, buffer, 32);
+    CX_THROW(cx_hash_no_throw(&u.shasha.header, CX_LAST, in, inlen, buffer, 32));
     cx_ripemd160_init(&u.riprip);
-    cx_hash(&u.riprip.header, CX_LAST, buffer, 32, out, 20);
+    CX_THROW(cx_hash_no_throw(&u.riprip.header, CX_LAST, buffer, 32, out, 20));
 }
 
 void compress_public_key(uint8_t *value) {
@@ -65,33 +65,33 @@ void derive_private_key(cx_ecfp_private_key_t *private_key,
                         uint8_t chain_code[static 32],
                         const uint32_t *bip32_path,
                         uint8_t bip32_path_len) {
-    uint8_t raw_private_key[32] = {0};
-
-    BEGIN_TRY {
-        TRY {
-            // derive the seed with 44'/280'/$(bip32_path)
-            os_perso_derive_node_bip32(CX_CURVE_256K1,
-                                       bip32_path,
-                                       bip32_path_len,
-                                       raw_private_key,
-                                       chain_code);
-            // new private_key from raw
-            cx_ecfp_init_private_key(CX_CURVE_256K1,
-                                     raw_private_key,
-                                     sizeof(raw_private_key),
-                                     private_key);
-        }
-        CATCH_OTHER(e) {
-            THROW(e);
-        }
-        FINALLY {
-            explicit_bzero(&raw_private_key, sizeof(raw_private_key));
-        }
+    uint8_t raw_private_key[64] = {0};
+    // derive the seed with 44'/280'/$(bip32_path)
+    cx_err_t err = os_derive_bip32_no_throw(CX_CURVE_256K1,
+                               bip32_path,
+                               bip32_path_len,
+                               raw_private_key,
+                               chain_code);
+    if (err != CX_OK) {
+        explicit_bzero(&raw_private_key, sizeof(raw_private_key));
+        THROW(err);
     }
-    END_TRY;
+    // new private_key from raw
+    err = cx_ecfp_init_private_key_no_throw(CX_CURVE_256K1,
+                             raw_private_key,
+                             sizeof(raw_private_key),
+                             private_key);
+
+    explicit_bzero(&raw_private_key, sizeof(raw_private_key));
+    if (err != CX_OK) {
+        THROW(err);
+    }
 }
 
 void init_public_key(cx_ecfp_private_key_t *private_key, cx_ecfp_public_key_t *public_key) {
     // generate corresponding public key
-    cx_ecfp_generate_pair(CX_CURVE_256K1, public_key, private_key, 1);
+    cx_err_t err = cx_ecfp_generate_pair_no_throw(CX_CURVE_256K1, public_key, private_key, 1);
+    if (err != CX_OK) {
+        THROW(err);
+    }
 }

--- a/src/io.c
+++ b/src/io.c
@@ -28,6 +28,7 @@ uint8_t io_event(uint8_t channel) {
                 THROW(EXCEPTION_IO_RESET);
             }
             /* fallthrough */
+            __attribute__((fallthrough));
         case SEPROXYHAL_TAG_DISPLAY_PROCESSED_EVENT:
             UX_DISPLAYED_EVENT({});
             break;

--- a/src/main.c
+++ b/src/main.c
@@ -60,6 +60,7 @@ void app_main() {
                        cmd.p1,
                        cmd.p2,
                        cmd.lc,
+                       cmd.lc,
                        cmd.data);
 
                 // Dispatch structured APDU command to handler


### PR DESCRIPTION
# Acceptance criteria

- Have no issues on all tests
- No build warnings

## Description

Some methods have been deprecated, these methods are specifically the methods that throw (error thowing was created as a C macro in Ledger SDK) in  favor of methods that return an error code.

If we look at the new implementation we can see that the methods just call the `_no_throw` variant and then `CX_THROW` the result, which means we can bring that implementation to our code to explicitly throw and suppress all warnings since throwing is not deprecated, just implicit throws.