### PR TITLE
chore: remove warn supression

### DIFF
--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -1,6 +1,3 @@
-#pragma GCC diagnostic ignored "-Wformat-invalid-specifier"  // snprintf
-#pragma GCC diagnostic ignored "-Wformat-extra-args"         // snprintf
-
 #include <stdint.h>
 #include <string.h>
 


### PR DESCRIPTION
# Description

The warning suppression was part of the original boilerplate which used `snprintf` to format the address into a hex string.
We implement a base58 formatter that does not use `snprintf` so the warning is not required.

# Acceptance criteria

Remove warning suppression